### PR TITLE
AB2D-5589 Ingest the dummy opt-out file from AWS S3 using the new Lam…

### DIFF
--- a/optout/build.gradle
+++ b/optout/build.gradle
@@ -12,10 +12,14 @@ repositories {
 
 dependencies {
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
+    implementation 'org.postgresql:postgresql:42.5.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
     testImplementation 'org.junit.platform:junit-platform-commons:1.9.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
     testImplementation 'org.mockito:mockito-core:4.8.0'
+    testImplementation 'org.testcontainers:junit-jupiter:1.17.6'
+    testImplementation "org.testcontainers:postgresql:1.17.6"
+    testImplementation 'org.postgresql:postgresql:42.5.1'
     testImplementation project(':lambda-test-utils')
     implementation(project(":lambda-lib"))
 }

--- a/optout/src/main/java/gov/cms/ab2d/optout/DatabaseUtil.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/DatabaseUtil.java
@@ -1,0 +1,30 @@
+package gov.cms.ab2d.optout;
+
+import gov.cms.ab2d.lambdalibs.lib.PropertiesUtil;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Properties;
+
+public class DatabaseUtil {
+
+    public static final int BATCH_INSERT_SIZE = 10000;
+    public static final String UPDATE_WITH_OPTOUT = "UPDATE public.coverage\n" +
+            "SET opt_out_flag = ?, " +
+            "effective_date = ?\n" +
+            "WHERE beneficiary_id = ?";
+
+    public static Connection getConnection() throws SQLException {
+        Properties properties = PropertiesUtil.loadProps();
+        return DriverManager.getConnection(properties.getProperty("DB_URL"), properties.getProperty("DB_USERNAME"), properties.getProperty("DB_PASSWORD"));
+    }
+
+    public static void prepareInsert(OptOutInformation optOut, PreparedStatement statement) throws SQLException {
+        statement.setBoolean(1, optOut.isOptOut());
+        statement.setTimestamp(2, optOut.getEffectiveDate());
+        statement.setInt(3, optOut.getMbi());
+        statement.addBatch();
+    }
+}

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutInformation.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutInformation.java
@@ -2,21 +2,20 @@ package gov.cms.ab2d.optout;
 
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
 
-import java.time.*;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
+import java.sql.Timestamp;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 public class OptOutInformation {
 
     private final int mbi;
 
-    private final OffsetDateTime effectiveDate;
+    private final Timestamp effectiveDate;
 
     private final boolean optOutFlag;
 
-    private final ZoneId zoneId = ZoneId.of("UTC");
-
-    public OptOutInformation(int mbi, OffsetDateTime effectiveDate, boolean optOutFlag) {
+    public OptOutInformation(int mbi, Timestamp effectiveDate, boolean optOutFlag) {
         this.mbi = mbi;
         this.optOutFlag = optOutFlag;
         this.effectiveDate = effectiveDate;
@@ -27,7 +26,7 @@ public class OptOutInformation {
             this.mbi = Integer.parseInt(information.substring(0, 11).trim());
             this.optOutFlag = (information.charAt(368) == 'N');
             this.effectiveDate = convertToOffsetDateTime(information.substring(354, 362));
-        } catch (NumberFormatException | StringIndexOutOfBoundsException | DateTimeParseException ex) {
+        } catch (NumberFormatException | StringIndexOutOfBoundsException | ParseException ex) {
             logger.log("Lambda can not parse the string: " + information);
             throw new IllegalArgumentException();
         }
@@ -37,7 +36,7 @@ public class OptOutInformation {
         return mbi;
     }
 
-    public OffsetDateTime getEffectiveDate() {
+    public Timestamp getEffectiveDate() {
         return effectiveDate;
     }
 
@@ -45,10 +44,10 @@ public class OptOutInformation {
         return optOutFlag;
     }
 
-    private OffsetDateTime convertToOffsetDateTime(String dateString) {
-        LocalDateTime date = LocalDate.parse(dateString, DateTimeFormatter.ofPattern("yyyyMMdd")).atStartOfDay();
-        ZoneOffset offset = zoneId.getRules().getOffset(date);
-        return OffsetDateTime.of(date, offset);
+    private Timestamp convertToOffsetDateTime(String dateString) throws ParseException {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd");
+        Date parsedDate = dateFormat.parse(dateString);
+        return new Timestamp(parsedDate.getTime());
     }
 
 }

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutConsumerTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutConsumerTest.java
@@ -2,9 +2,12 @@ package gov.cms.ab2d.optout;
 
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.concurrent.BlockingQueue;
@@ -12,13 +15,16 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class OptOutConsumerTest {
 
     @Test
-    public void optOutConsumerRunTest() throws InterruptedException {
+    public void optOutConsumerRunTest() throws InterruptedException, SQLException {
         Connection dbConnection = Mockito.mock(Connection.class);
+        when(dbConnection.prepareStatement(any())).thenReturn(Mockito.mock(PreparedStatement.class));
         CountDownLatch latch = Mockito.mock(CountDownLatch.class);
         LambdaLogger logger = Mockito.mock(LambdaLogger.class);
         BlockingQueue<OptOutMessage> queue = new LinkedBlockingQueue<>();

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutConsumerTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutConsumerTest.java
@@ -4,7 +4,9 @@ import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.time.OffsetDateTime;
+import java.sql.Connection;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -16,14 +18,15 @@ public class OptOutConsumerTest {
 
     @Test
     public void optOutConsumerRunTest() throws InterruptedException {
+        Connection dbConnection = Mockito.mock(Connection.class);
         CountDownLatch latch = Mockito.mock(CountDownLatch.class);
         LambdaLogger logger = Mockito.mock(LambdaLogger.class);
         BlockingQueue<OptOutMessage> queue = new LinkedBlockingQueue<>();
 
-        queue.put(new OptOutMessage(new OptOutInformation(1, OffsetDateTime.now(), true), false));
+        queue.put(new OptOutMessage(new OptOutInformation(1, Timestamp.valueOf(LocalDateTime.now()), true), false));
         queue.put(new OptOutMessage(null, true));
 
-        new OptOutConsumer(queue, latch, logger).run();
+        new OptOutConsumer(queue, dbConnection, latch, logger).run();
 
         assertTrue(queue.isEmpty());
 

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutHandlerTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutHandlerTest.java
@@ -1,11 +1,21 @@
 package gov.cms.ab2d.optout;
 
+import gov.cms.ab2d.testutils.AB2DPostgresqlContainer;
 import gov.cms.ab2d.testutils.TestContext;
+
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+@Testcontainers
 public class OptOutHandlerTest {
+
+    @SuppressWarnings({"rawtypes", "unused"})
+    @Container
+    private static final PostgreSQLContainer POSTGRE_SQL_CONTAINER = new AB2DPostgresqlContainer();
 
     @Test
     void optOutHandlerInvoke() {


### PR DESCRIPTION
## 🎫 Ticket

[AB2D-5589](https://jira.cms.gov/browse/AB2D-5589) - Ingest the dummy opt-out file from AWS S3 using the new Lambda into the local database

## 🛠 Changes

Added Update statement to the opt-out lambda

## ℹ️ Context for reviewers

Opt-out :
STEP 1: On a weekly basis AB2D makes calls to BFD to retrieve contract bene mappings and store on AB2D database.
Step 2: Ab2d need to read that flat file with opted out bene data from BFD s3 update in AB2d database.

This PR addresses part 2 to create update opt-out and effective date values in public.coverage table.

## ✅ Acceptance Validation

Updated unit tests and created follow-up ticket to connect to ab2d database from Lambda.
## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
