### PR TITLE
AB2D-5568 - Read the dummy opt-out file from AWS S3 using the new Lambda

### DIFF
--- a/optout/build.gradle
+++ b/optout/build.gradle
@@ -13,6 +13,7 @@ repositories {
 dependencies {
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'org.postgresql:postgresql:42.5.1'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.13'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
     testImplementation 'org.junit.platform:junit-platform-commons:1.9.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'

--- a/optout/src/main/java/gov/cms/ab2d/optout/Constants.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/Constants.java
@@ -1,0 +1,17 @@
+package gov.cms.ab2d.optout;
+
+import com.amazonaws.regions.Regions;
+
+public class Constants {
+
+    public static final String s3BucketName = "ab2d-opt-out-temp-349849222861-us-east-1";
+
+    public static final Regions s3Region = Regions.US_EAST_1;
+
+    public static final String fileName = "optOutDummy.txt";
+
+    public static final String filePath = "/opt/" + fileName;
+
+
+
+}

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutHandler.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutHandler.java
@@ -1,13 +1,15 @@
 package gov.cms.ab2d.optout;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -21,6 +23,8 @@ public class OptOutHandler implements RequestStreamHandler {
         LambdaLogger logger = context.getLogger();
         logger.log("OptOut Lambda is started");
 
+      //  downloadFileFromS3(logger);
+
         //ToDo: important! add capacity for backpressure
         BlockingQueue<OptOutMessage> queue = new LinkedBlockingQueue<>();
 
@@ -31,13 +35,21 @@ public class OptOutHandler implements RequestStreamHandler {
         //ToDo: replace on S3
         ClassLoader classLoader = getClass().getClassLoader();
         try {
-            File file = new File(Objects.requireNonNull(classLoader.getResource("optOutDummy.txt")).getFile());
+            File file = new File(Objects.requireNonNull(classLoader.getResource(Constants.fileName)).getFile());
+            //for s3
+          //  File file = new File(Constants.filePath);
             Connection dbConnection = DatabaseUtil.getConnection();
 
             executorService.execute(new OptOutProducer(queue, file, latch, logger));
             executorService.execute(new OptOutConsumer(queue, dbConnection, latch, logger));
 
             latch.await();
+
+//            if (file.delete()) {
+//                System.out.println("Deleted the file: " + Constants.fileName);
+//            } else {
+//                System.out.println("Failed to delete the file.");
+//            }
         } catch (NullPointerException | SQLException | InterruptedException ex) {
             logger.log(ex.getMessage());
             outputStream.write(ex.getMessage().getBytes(StandardCharsets.UTF_8));
@@ -46,8 +58,34 @@ public class OptOutHandler implements RequestStreamHandler {
             shutdownAndAwaitTermination(executorService, logger);
             outputStream.write("OptOut Lambda Completed".getBytes(StandardCharsets.UTF_8));
         }
-
     }
+    //Commented to avoid unnecessary work with temporary credentials
+/*
+    private void downloadFileFromS3(LambdaLogger logger) {
+        logger.log("Downloading " + Constants.fileName + " from S3 bucket " + Constants.s3BucketName);
+        final AmazonS3 s3 = AmazonS3ClientBuilder.standard()
+                .withRegion(Constants.s3Region).build();
+        try {
+            S3Object o = s3.getObject(Constants.s3BucketName, Constants.fileName);
+            S3ObjectInputStream s3is = o.getObjectContent();
+            FileOutputStream fos = new FileOutputStream(Constants.filePath);
+            byte[] read_buf = new byte[1024];
+            int read_len = 0;
+            while ((read_len = s3is.read(read_buf)) > 0) {
+                fos.write(read_buf, 0, read_len);
+            }
+            s3is.close();
+            fos.close();
+        } catch (AmazonServiceException ex) {
+            logger.log(ex.getErrorMessage());
+            throw new OptOutException(ex);
+        } catch (IOException ex) {
+            logger.log(ex.getMessage());
+            throw new OptOutException(ex);
+        }
+    }
+
+ */
 
     private void shutdownAndAwaitTermination(ExecutorService executorService, LambdaLogger logger) {
         logger.log("Call ThreadPoll shutdown");

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutConsumerTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutConsumerTest.java
@@ -2,7 +2,6 @@ package gov.cms.ab2d.optout;
 
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import java.sql.Connection;


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-5568

## 🛠 Changes

Added downloading dummy file from AB2D S3 bucket

## ℹ️ Context for reviewers

Opt-out :
STEP 1: On a weekly basis AB2D makes calls to BFD to retrieve contract bene mappings and store on AB2D database.
Step 2: Ab2d need to read that flat file with opted out bene data from BFD s3 update in AB2d database.

This PR addresses part 2 to download opt out file from S3 bucket

## ✅ Acceptance Validation

Manually tested on local environment 

## 🔒 Security Implications

- [ x] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
