### PR TITLE
[AB2D-6124] Add Opt Out Metrics to Slack Message

### DIFF
--- a/optout/src/main/java/gov/cms/ab2d/optout/CountResults.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/CountResults.java
@@ -1,0 +1,25 @@
+package gov.cms.ab2d.optout;
+
+public class CountResults {
+
+    private final int totalFromDB;
+    private final int optInToday;
+    private final int optOutToday;
+
+    public CountResults(int totalFromDB, int optInToday, int optOutToday){
+        this.totalFromDB = totalFromDB;
+        this.optInToday = optInToday;
+        this.optOutToday = optOutToday;
+    }
+
+    public int getTotalFromDB(){
+        return totalFromDB;
+    }
+    public int getOptInToday(){
+        return optInToday;
+    }
+    public int getOptOutToday(){
+        return optOutToday;
+    }
+
+}

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutConstants.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutConstants.java
@@ -24,12 +24,8 @@ public class OptOutConstants {
     public static final String UPDATE_STATEMENT = "UPDATE public.current_mbi\n" +
             "SET opt_out_flag = ?, effective_date = current_date\n" +
             "WHERE mbi = ?";
-    
-    // TODO: Verify that this is correct?
-    // I think we use a view for this table for performance reasons.
-    // If so, this will be different
-    public static final String SELECT_OPT_OUT_FLAG_STATEMENT = "SELECT opt_out_flag FROM public.current_mbi";
 
+    public static final String COUNT_STATEMENT = "select count(*) from current_mbi where opt_out_flag is not null";
     private OptOutConstants() {
     }
 }

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutConstants.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutConstants.java
@@ -24,8 +24,10 @@ public class OptOutConstants {
     public static final String UPDATE_STATEMENT = "UPDATE public.current_mbi\n" +
             "SET opt_out_flag = ?, effective_date = current_date\n" +
             "WHERE mbi = ?";
+    public static final String COUNT_STATEMENT = "SELECT \n"+
+        "COUNT(CASE WHEN opt_out_flag = 'true' THEN 1 END) AS optin, \n"+
+        "COUNT(CASE WHEN opt_out_flag = 'false' THEN 1 END) AS optout \n"+
+        "FROM current_mbi WHERE opt_out_flag IS NOT NULL";
 
-    public static final String COUNT_STATEMENT = "select count(*) AS total from current_mbi where opt_out_flag is not null";
-    private OptOutConstants() {
-    }
+    private OptOutConstants() {}
 }

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutConstants.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutConstants.java
@@ -24,6 +24,11 @@ public class OptOutConstants {
     public static final String UPDATE_STATEMENT = "UPDATE public.current_mbi\n" +
             "SET opt_out_flag = ?, effective_date = current_date\n" +
             "WHERE mbi = ?";
+    
+    // TODO: Verify that this is correct?
+    // I think we use a view for this table for performance reasons.
+    // If so, this will be different
+    public static final String SELECT_OPT_OUT_FLAG_STATEMENT = "SELECT opt_out_flag FROM public.current_mbi";
 
     private OptOutConstants() {
     }

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutConstants.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutConstants.java
@@ -25,7 +25,7 @@ public class OptOutConstants {
             "SET opt_out_flag = ?, effective_date = current_date\n" +
             "WHERE mbi = ?";
 
-    public static final String COUNT_STATEMENT = "select count(*) from current_mbi where opt_out_flag is not null";
+    public static final String COUNT_STATEMENT = "select count(*) AS total from current_mbi where opt_out_flag is not null";
     private OptOutConstants() {
     }
 }

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutHandler.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutHandler.java
@@ -31,10 +31,10 @@ public class OptOutHandler implements RequestHandler<SQSEvent, Void> {
             var notification = S3EventNotification.parseJson(s3EventMessage.toString()).getRecords().get(0);
 
             var optOutProcessing = processorInit(logger);
-            var countRes = optOutProcessing.process(getFileName(notification), getBucketName(notification), ENDPOINT);
-            if (countRes != null) {
-                logger.log("OptOut Lambda completed. Total records processed today=" + countRes.getTotalToday()
-                    + " Total records processed to date=" + countRes.getTotalFromDB());
+            var optOutResults = optOutProcessing.process(getFileName(notification), getBucketName(notification), ENDPOINT);
+            if (optOutResults != null) {
+                logger.log("OptOut Lambda completed. Total records processed today=" + optOutResults.getTotalToday()
+                    + " Total records processed to date=" + optOutResults.getTotalFromDB());
             }
         } catch (Exception ex) {
             logger.log("An error occurred");

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutHandler.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutHandler.java
@@ -32,18 +32,22 @@ public class OptOutHandler implements RequestHandler<SQSEvent, Void> {
 
             var optOutProcessing = processorInit(logger);
             var optOutResults = optOutProcessing.process(getFileName(notification), getBucketName(notification), ENDPOINT);
-            if (optOutResults != null) {
-                logger.log("OptOut Lambda completed. Total records processed today is: totaltoday=" + optOutResults.getTotalToday()
-                    + " Number of opt in today is: todayin=" + optOutResults.getOptInToday()
-                    + " Number of opt out today is: todayout=" + optOutResults.getOptOutToday()
-                    + " Total records processed to date is: totaltodate=" + optOutResults.getTotalAllTime()
-                    + " Total number of opt in is: totalin=" + optOutResults.getOptInTotal()
-                    + " Total number of opt out is: totalout=" + optOutResults.getOptOutTotal()
-                );
-            }
+            logResults(optOutResults, logger);
         } catch (Exception ex) {
             logger.log("An error occurred");
             throw new OptOutException("An error occurred", ex);
+        }
+    }
+
+    public void logResults(OptOutResults optOutResults, LambdaLogger logger) {
+        if (optOutResults != null) {
+            logger.log("OptOut Lambda completed. Total records processed today is: totaltoday=" + optOutResults.getTotalToday()
+                + " Number of opt in today is: todayin=" + optOutResults.getOptInToday()
+                + " Number of opt out today is: todayout=" + optOutResults.getOptOutToday()
+                + " Total records processed to date is: totaltodate=" + optOutResults.getTotalAllTime()
+                + " Total number of opt in is: totalin=" + optOutResults.getOptInTotal()
+                + " Total number of opt out is: totalout=" + optOutResults.getOptOutTotal()
+            );
         }
     }
 

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutHandler.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutHandler.java
@@ -33,10 +33,13 @@ public class OptOutHandler implements RequestHandler<SQSEvent, Void> {
             var optOutProcessing = processorInit(logger);
             var optOutResults = optOutProcessing.process(getFileName(notification), getBucketName(notification), ENDPOINT);
             if (optOutResults != null) {
-                logger.log("OptOut Lambda completed. Total records processed today=" + optOutResults.getTotalToday()
-                    + " Number of opt in=" + optOutResults.getOptInToday()
-                    + " Number of opt out=" + optOutResults.getOptOutToday()
-                    + " Total records processed to date=" + optOutResults.getTotalFromDB());
+                logger.log("OptOut Lambda completed. Total records processed today is: totaltoday=" + optOutResults.getTotalToday()
+                    + " Number of opt in today is: todayin=" + optOutResults.getOptInToday()
+                    + " Number of opt out today is: todayout=" + optOutResults.getOptOutToday()
+                    + " Total records processed to date is: totaltodate=" + optOutResults.getTotalAllTime()
+                    + " Total number of opt in is: totalin=" + optOutResults.getOptInTotal()
+                    + " Total number of opt out is: totalout=" + optOutResults.getOptOutTotal()
+                );
             }
         } catch (Exception ex) {
             logger.log("An error occurred");

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutHandler.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutHandler.java
@@ -10,46 +10,13 @@ import org.json.simple.parser.JSONParser;
 
 import static gov.cms.ab2d.optout.OptOutConstants.ENDPOINT;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class OptOutHandler implements RequestHandler<SQSEvent, Void> {
-
-    private List<OptOutInformation> requestOptOutInformationList;
 
     @Override
     public Void handleRequest(SQSEvent sqsEvent, Context context) {
-        requestOptOutInformationList = new ArrayList<>();
-
         for (SQSEvent.SQSMessage msg : sqsEvent.getRecords()) {
             processSQSMessage(msg, context);
         }
-
-        int totalNumberOfProcessedOptOuts = requestOptOutInformationList.size();
-        int numberOfYOptOuts = 0;
-        int numberOfNOptOuts = 0;
-
-        for (OptOutInformation optOut : requestOptOutInformationList) {
-            if (optOut.getOptOutFlag()) {
-                numberOfYOptOuts++;
-            } else {
-                numberOfNOptOuts++;
-            }
-        }
-
-        // TODO: Get the total number of opt-outs processed to date.
-        // I Added a select statement in constants for that should do that
-        // But need to double check if it is correct, since I think we may use a view
-        // and not the 'real' table for performance reasons.
-        
-        String optOutCompletedMessage = String.format(
-            "OptOut Lambda completed. Processed %d optout information records this run" +
-            " with %d opted out, and %d opted in for data sharing.",
-            totalNumberOfProcessedOptOuts, numberOfYOptOuts, numberOfNOptOuts
-        );
-        context.getLogger().log(optOutCompletedMessage);
-
-        requestOptOutInformationList.clear();
         return null;
     }
 
@@ -64,11 +31,13 @@ public class OptOutHandler implements RequestHandler<SQSEvent, Void> {
             var notification = S3EventNotification.parseJson(s3EventMessage.toString()).getRecords().get(0);
 
             var optOutProcessing = processorInit(logger);
-            optOutProcessing.process(getFileName(notification), getBucketName(notification), ENDPOINT);
-            
-            // Is there a reason the optOutInformationList is public?
-            // Would it be better to make it private and use a getter of the processor?
-            requestOptOutInformationList.addAll(optOutProcessing.optOutInformationList);
+            var countRes = optOutProcessing.process(getFileName(notification), getBucketName(notification), ENDPOINT);
+
+            logger.log("OptOut Lambda completed. Total=" + countRes.getTotalFromDB()
+                    + " In=" + countRes.getOptInToday()
+                    + " Out=" + countRes.getOptOutToday());
+
+
         } catch (Exception ex) {
             logger.log("An error occurred");
             throw new OptOutException("An error occurred", ex);

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutHandler.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutHandler.java
@@ -32,10 +32,10 @@ public class OptOutHandler implements RequestHandler<SQSEvent, Void> {
 
             var optOutProcessing = processorInit(logger);
             var countRes = optOutProcessing.process(getFileName(notification), getBucketName(notification), ENDPOINT);
-
-            logger.log("OptOut Lambda completed. Total=" + countRes.getTotalFromDB()
-                    + " In=" + countRes.getOptInToday()
-                    + " Out=" + countRes.getOptOutToday());
+            if (countRes != null)
+                logger.log("OptOut Lambda completed. Total=" + countRes.getTotalFromDB()
+                        + " In=" + countRes.getOptInToday()
+                        + " Out=" + countRes.getOptOutToday());
 
 
         } catch (Exception ex) {

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutHandler.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutHandler.java
@@ -32,12 +32,10 @@ public class OptOutHandler implements RequestHandler<SQSEvent, Void> {
 
             var optOutProcessing = processorInit(logger);
             var countRes = optOutProcessing.process(getFileName(notification), getBucketName(notification), ENDPOINT);
-            if (countRes != null)
-                logger.log("OptOut Lambda completed. Total=" + countRes.getTotalFromDB()
-                        + " In=" + countRes.getOptInToday()
-                        + " Out=" + countRes.getOptOutToday());
-
-
+            if (countRes != null) {
+                logger.log("OptOut Lambda completed. Total records processed today=" + countRes.getTotalToday()
+                    + " Total records processed to date=" + countRes.getTotalFromDB());
+            }
         } catch (Exception ex) {
             logger.log("An error occurred");
             throw new OptOutException("An error occurred", ex);

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutHandler.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutHandler.java
@@ -34,6 +34,8 @@ public class OptOutHandler implements RequestHandler<SQSEvent, Void> {
             var optOutResults = optOutProcessing.process(getFileName(notification), getBucketName(notification), ENDPOINT);
             if (optOutResults != null) {
                 logger.log("OptOut Lambda completed. Total records processed today=" + optOutResults.getTotalToday()
+                    + " Number of opt in=" + optOutResults.getOptInToday()
+                    + " Number of opt out=" + optOutResults.getOptOutToday()
                     + " Total records processed to date=" + optOutResults.getTotalFromDB());
             }
         } catch (Exception ex) {

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutInformation.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutInformation.java
@@ -2,12 +2,12 @@ package gov.cms.ab2d.optout;
 
 public class OptOutInformation {
     private final String mbi;
-    private final Boolean optOutFlag;
-    public OptOutInformation(String mbi, Boolean optOutFlag) {
+    private final boolean optOutFlag;
+    public OptOutInformation(String mbi, boolean optOutFlag) {
         this.mbi = mbi;
         this.optOutFlag = optOutFlag;
     }
-    public Boolean getOptOutFlag() {
+    public boolean getOptOutFlag() {
         return optOutFlag;
     }
     public String getMbi() {

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
@@ -154,7 +154,6 @@ public class OptOutProcessor {
                     numberOptedOut++;
                 }
             }
-            //delete
             return new OptOutResults(totalFromDb, numberOptedIn, numberOptedOut);
         } catch (SQLException ex) {
            logger.log("There is an error " + ex.getMessage());

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
@@ -135,13 +135,16 @@ public class OptOutProcessor {
     }
 
     public OptOutResults getOptOutResults() {
-        int totalFromDb = 0;
+        int totalOptedIn = 0;
+        int totalOptedOut = 0;
+
         try (var dbConnection = DriverManager.getConnection(parameterStore.getDbHost(), parameterStore.getDbUser(), parameterStore.getDbPassword());
              var statement = dbConnection.createStatement();
              ResultSet rs = statement.executeQuery(COUNT_STATEMENT)
         ) {
             while (rs.next()) {
-                totalFromDb = rs.getInt("total");
+                totalOptedIn = rs.getInt("optin");
+                totalOptedOut = rs.getInt("optout");
             }
 
             int numberOptedIn = 0;
@@ -154,7 +157,7 @@ public class OptOutProcessor {
                     numberOptedOut++;
                 }
             }
-            return new OptOutResults(totalFromDb, numberOptedIn, numberOptedOut);
+            return new OptOutResults(numberOptedIn, numberOptedOut, totalOptedIn, totalOptedOut);
         } catch (SQLException ex) {
            logger.log("There is an error " + ex.getMessage());
         }

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
@@ -135,13 +135,15 @@ public class OptOutProcessor {
     }
 
     public CountResults getCountsOptOut() {
-        int total = 0;
+        int totalFromDb = 0;
         try (var dbConnection = DriverManager.getConnection(parameterStore.getDbHost(), parameterStore.getDbUser(), parameterStore.getDbPassword());
              var statement = dbConnection.createStatement();
              ResultSet rs = statement.executeQuery(COUNT_STATEMENT)
         ) {
             while (rs.next()) {
-                total = rs.getInt(0);
+                logger.log("Inside RS");
+                logger.log("rs.getInt(0) " + rs.getInt("total"));
+                totalFromDb = rs.getInt("total");
             }
             //rename:
             int numberOfYOptOuts = 0;
@@ -155,9 +157,9 @@ public class OptOutProcessor {
                 }
             }
             //delete
-            logger.log("Total = " + total);
+            logger.log("Total = " + totalFromDb);
             logger.log("numberOfYOptOuts = " + numberOfYOptOuts);
-            return new CountResults(total, numberOfYOptOuts, numberOfNOptOuts);
+            return new CountResults(totalFromDb, numberOfYOptOuts, numberOfNOptOuts);
         } catch (SQLException e) {
            logger.log("???");
         }

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
@@ -140,6 +140,8 @@ public class OptOutProcessor {
              var statement = dbConnection.createStatement();
              ResultSet rs = statement.executeQuery(COUNT_STATEMENT)
         ) {
+            logger.log("statement " + statement);
+            logger.log("RS " + rs);
             while (rs.next()) {
                 logger.log("Inside RS");
                 logger.log("rs.getInt(0) " + rs.getInt("total"));
@@ -161,7 +163,7 @@ public class OptOutProcessor {
             logger.log("numberOfYOptOuts = " + numberOfYOptOuts);
             return new CountResults(totalFromDb, numberOfYOptOuts, numberOfNOptOuts);
         } catch (SQLException e) {
-           logger.log("???");
+           logger.log("---------!" + e.getMessage());
         }
         return null;
     }

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
@@ -140,11 +140,7 @@ public class OptOutProcessor {
              var statement = dbConnection.createStatement();
              ResultSet rs = statement.executeQuery(COUNT_STATEMENT)
         ) {
-            logger.log("statement " + statement);
-            logger.log("RS " + rs);
             while (rs.next()) {
-                logger.log("Inside RS");
-                logger.log("rs.getInt(0) " + rs.getInt("total"));
                 totalFromDb = rs.getInt("total");
             }
             //rename:
@@ -159,11 +155,9 @@ public class OptOutProcessor {
                 }
             }
             //delete
-            logger.log("Total = " + totalFromDb);
-            logger.log("numberOfYOptOuts = " + numberOfYOptOuts);
             return new CountResults(totalFromDb, numberOfYOptOuts, numberOfNOptOuts);
-        } catch (SQLException e) {
-           logger.log("---------!" + e.getMessage());
+        } catch (SQLException ex) {
+           logger.log("There is an error " + ex.getMessage());
         }
         return null;
     }

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
@@ -151,7 +151,7 @@ public class OptOutProcessor {
             int numberOptedOut = 0;
 
             for (OptOutInformation optOut : optOutInformationList) {
-                if (optOut.getOptOutFlag()) {
+                if (optOut.getOptOutFlag() == true) {
                     numberOptedIn++;
                 } else {
                     numberOptedOut++;

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
@@ -151,7 +151,7 @@ public class OptOutProcessor {
             int numberOptedOut = 0;
 
             for (OptOutInformation optOut : optOutInformationList) {
-                if (optOut.getOptOutFlag() == true) {
+                if (Boolean.TRUE.equals(optOut.getOptOutFlag())) {
                     numberOptedIn++;
                 } else {
                     numberOptedOut++;

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
@@ -154,6 +154,9 @@ public class OptOutProcessor {
                     numberOfNOptOuts++;
                 }
             }
+            //delete
+            logger.log("Total = " + total);
+            logger.log("numberOfYOptOuts = " + numberOfYOptOuts);
             return new CountResults(total, numberOfYOptOuts, numberOfNOptOuts);
         } catch (SQLException e) {
            logger.log("???");

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutProcessor.java
@@ -151,7 +151,7 @@ public class OptOutProcessor {
             int numberOptedOut = 0;
 
             for (OptOutInformation optOut : optOutInformationList) {
-                if (Boolean.TRUE.equals(optOut.getOptOutFlag())) {
+                if (optOut.getOptOutFlag()) {
                     numberOptedIn++;
                 } else {
                     numberOptedOut++;

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutResults.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutResults.java
@@ -1,25 +1,31 @@
 package gov.cms.ab2d.optout;
 
-public class CountResults {
+public class OptOutResults {
 
     private final int totalFromDB;
     private final int optInToday;
     private final int optOutToday;
 
-    public CountResults(int totalFromDB, int optInToday, int optOutToday){
+    public OptOutResults(int totalFromDB, int optInToday, int optOutToday){
         this.totalFromDB = totalFromDB;
         this.optInToday = optInToday;
         this.optOutToday = optOutToday;
     }
 
-    public int getTotalFromDB(){
+    public int getTotalFromDB() {
         return totalFromDB;
     }
-    public int getOptInToday(){
+    
+    public int getOptInToday() {
         return optInToday;
     }
-    public int getOptOutToday(){
+
+    public int getOptOutToday() {
         return optOutToday;
+    }
+
+    public int getTotalToday() {
+        return optInToday + optOutToday;
     }
 
 }

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutResults.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutResults.java
@@ -2,18 +2,16 @@ package gov.cms.ab2d.optout;
 
 public class OptOutResults {
 
-    private final int totalFromDB;
     private final int optInToday;
     private final int optOutToday;
+    private final int optInTotal;
+    private final int optOutTotal;
 
-    public OptOutResults(int totalFromDB, int optInToday, int optOutToday) {
-        this.totalFromDB = totalFromDB;
+    public OptOutResults(int optInToday, int optOutToday, int optInTotal, int optOutTotal) {
         this.optInToday = optInToday;
         this.optOutToday = optOutToday;
-    }
-
-    public int getTotalFromDB() {
-        return totalFromDB;
+        this.optInTotal = optInTotal;
+        this.optOutTotal = optOutTotal;
     }
 
     public int getOptInToday() {
@@ -26,6 +24,18 @@ public class OptOutResults {
 
     public int getTotalToday() {
         return optInToday + optOutToday;
+    }
+
+    public int getOptInTotal() {
+        return optInTotal;
+    }
+
+    public int getOptOutTotal() {
+        return optOutTotal;
+    }
+
+    public int getTotalAllTime() {
+        return optInTotal + optOutTotal;
     }
 
 }

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutResults.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutResults.java
@@ -6,7 +6,7 @@ public class OptOutResults {
     private final int optInToday;
     private final int optOutToday;
 
-    public OptOutResults(int totalFromDB, int optInToday, int optOutToday){
+    public OptOutResults(int totalFromDB, int optInToday, int optOutToday) {
         this.totalFromDB = totalFromDB;
         this.optInToday = optInToday;
         this.optOutToday = optOutToday;
@@ -15,7 +15,7 @@ public class OptOutResults {
     public int getTotalFromDB() {
         return totalFromDB;
     }
-    
+
     public int getOptInToday() {
         return optInToday;
     }

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutHandlerTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutHandlerTest.java
@@ -15,6 +15,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -22,6 +23,8 @@ import java.util.Collections;
 import static gov.cms.ab2d.optout.OptOutConstantsTest.*;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @Testcontainers
@@ -59,8 +62,23 @@ class OptOutHandlerTest {
         when(context.getLogger()).thenReturn(logger);
 
         assertThrows(OptOutException.class, () ->  handler.handleRequest(sqsEvent, context));
+        verify(handler, times(1)).processSQSMessage(sqsMessage, context);
+        verify(logger, times(1)).log(anyString());
     }
 
+    @Test
+    void itDoesNotLogWhenResultsAreNull() throws URISyntaxException {
+        Context context = mock(Context.class);
+        LambdaLogger logger = mock(LambdaLogger.class);
+        OptOutProcessor processor = mock(OptOutProcessor.class);
+        
+        when(context.getLogger()).thenReturn(logger);
+        when(handler.processorInit(any())).thenReturn(processor);
+        when(processor.process(anyString(), anyString(), anyString())).thenReturn(null);
+
+        handler.handleRequest(sqsEvent, context);
+        verify(logger, times(0)).log(anyString());
+    }
 
     static private String getPayload() throws IOException {
         return Files.readString(Paths.get("src/test/resources/sqsEvent.json"));

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutHandlerTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutHandlerTest.java
@@ -67,16 +67,28 @@ class OptOutHandlerTest {
     }
 
     @Test
+    void itLogsResults() {
+        LambdaLogger logger = mock(LambdaLogger.class);
+        OptOutResults optOutResults = new OptOutResults(1, 1, 2, 2);
+
+        String loggedMessage = "OptOut Lambda completed. Total records processed today is: totaltoday=" + optOutResults.getTotalToday()
+                + " Number of opt in today is: todayin=" + optOutResults.getOptInToday()
+                + " Number of opt out today is: todayout=" + optOutResults.getOptOutToday()
+                + " Total records processed to date is: totaltodate=" + optOutResults.getTotalAllTime()
+                + " Total number of opt in is: totalin=" + optOutResults.getOptInTotal()
+                + " Total number of opt out is: totalout=" + optOutResults.getOptOutTotal();
+
+        handler.logResults(optOutResults, logger);
+        verify(logger, times(1)).log(loggedMessage);
+    }
+
+    @Test
     void itDoesNotLogWhenResultsAreNull() throws URISyntaxException {
         Context context = mock(Context.class);
         LambdaLogger logger = mock(LambdaLogger.class);
-        OptOutProcessor processor = mock(OptOutProcessor.class);
         
         when(context.getLogger()).thenReturn(logger);
-        when(handler.processorInit(any())).thenReturn(processor);
-        when(processor.process(anyString(), anyString(), anyString())).thenReturn(null);
-
-        handler.handleRequest(sqsEvent, context);
+        handler.logResults(null, logger);
         verify(logger, times(0)).log(anyString());
     }
 

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutHandlerTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutHandlerTest.java
@@ -15,7 +15,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -23,7 +22,6 @@ import java.util.Collections;
 import static gov.cms.ab2d.optout.OptOutConstantsTest.*;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -61,9 +59,9 @@ class OptOutHandlerTest {
         LambdaLogger logger = mock(LambdaLogger.class);
         when(context.getLogger()).thenReturn(logger);
 
-        assertThrows(OptOutException.class, () ->  handler.handleRequest(sqsEvent, context));
+        assertThrows(OptOutException.class, () -> handler.handleRequest(sqsEvent, context));
         verify(handler, times(1)).processSQSMessage(sqsMessage, context);
-        verify(logger, times(1)).log(anyString());
+        verify(logger, times(2)).log(anyString());
     }
 
     @Test
@@ -71,22 +69,15 @@ class OptOutHandlerTest {
         LambdaLogger logger = mock(LambdaLogger.class);
         OptOutResults optOutResults = new OptOutResults(1, 1, 2, 2);
 
-        String loggedMessage = "OptOut Lambda completed. Total records processed today is: totaltoday=" + optOutResults.getTotalToday()
-                + " Number of opt in today is: todayin=" + optOutResults.getOptInToday()
-                + " Number of opt out today is: todayout=" + optOutResults.getOptOutToday()
-                + " Total records processed to date is: totaltodate=" + optOutResults.getTotalAllTime()
-                + " Total number of opt in is: totalin=" + optOutResults.getOptInTotal()
-                + " Total number of opt out is: totalout=" + optOutResults.getOptOutTotal();
-
         handler.logResults(optOutResults, logger);
-        verify(logger, times(1)).log(loggedMessage);
+        verify(logger, times(1)).log(anyString());
     }
 
     @Test
-    void itDoesNotLogWhenResultsAreNull() throws URISyntaxException {
+    void itDoesNotLogWhenResultsAreNull() {
         Context context = mock(Context.class);
         LambdaLogger logger = mock(LambdaLogger.class);
-        
+
         when(context.getLogger()).thenReturn(logger);
         handler.logResults(null, logger);
         verify(logger, times(0)).log(anyString());

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutProcessorTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutProcessorTest.java
@@ -156,6 +156,8 @@ class OptOutProcessorTest {
     void getOptOutResultsTest() {
         OptOutResults results = optOutProcessing.getOptOutResults();
         assertNotNull(results);
+        System.out.println("Results = " + results);
+        System.out.println("ResultsFromDB = " + results.getTotalFromDB());
         assertEquals(TEST_TOTAL_RESULT_COUNT, results.getTotalFromDB());;
     }
 

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutProcessorTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutProcessorTest.java
@@ -74,6 +74,8 @@ class OptOutProcessorTest {
         OptOutResults results = optOutProcessing.process(TEST_FILE_NAME, TEST_BFD_BUCKET_NAME, TEST_ENDPOINT);
         assertEquals(7, optOutProcessing.optOutInformationList.size());
         assertEquals(7, results.getTotalToday());
+        assertEquals(4, results.getOptOutToday());
+        assertEquals(3, results.getOptInToday());
     }
 
     @Test

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutProcessorTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutProcessorTest.java
@@ -155,7 +155,8 @@ class OptOutProcessorTest {
     @Test
     void getOptOutResultsTest() {
         OptOutResults results = optOutProcessing.getOptOutResults();
-        assertEquals(results, null);
+        assertNotNull(results);
+        assertEquals(TEST_TOTAL_RESULT_COUNT, results.getTotalFromDB());;
     }
 
 }

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutProcessorTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutProcessorTest.java
@@ -154,15 +154,15 @@ class OptOutProcessorTest {
 
     @Test
     void getOptOutResultsTest() throws SQLException {
-        final String OPT_IN_RESULTSET_STRING = "optin";
-        final String OPT_OUT_RESULTSET_STRING = "optout";
+        final String optInResultSetString = "optin";
+        final String optOutResultSetString = "optout";
 
-        final int OPT_IN_TOTAL = 9;
-        final int OPT_OUT_TOTAL = 7;
+        final int optInTotalCount = 9;
+        final int optOutTotalCount = 7;
 
         when(resultSet.next()).thenReturn(true).thenReturn(false);
-        when(resultSet.getInt(OPT_IN_RESULTSET_STRING)).thenReturn(OPT_IN_TOTAL);
-        when(resultSet.getInt(OPT_OUT_RESULTSET_STRING)).thenReturn(OPT_OUT_TOTAL);
+        when(resultSet.getInt(optInResultSetString)).thenReturn(optInTotalCount);
+        when(resultSet.getInt(optOutResultSetString)).thenReturn(optOutTotalCount);
 
         optOutProcessing.optOutInformationList.add(new OptOutInformation(MBI, true));
         optOutProcessing.optOutInformationList.add(new OptOutInformation("DUMMY000002", false));
@@ -171,8 +171,8 @@ class OptOutProcessorTest {
         assertNotNull(results);
         assertEquals(1, results.getOptInToday());
         assertEquals(1, results.getOptOutToday());
-        assertEquals(OPT_IN_TOTAL, results.getOptInTotal());
-        assertEquals(OPT_OUT_TOTAL, results.getOptOutTotal());
+        assertEquals(optInTotalCount, results.getOptInTotal());
+        assertEquals(optOutTotalCount, results.getOptOutTotal());
     }
 
 }

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutProcessorTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutProcessorTest.java
@@ -73,7 +73,7 @@ class OptOutProcessorTest {
         
         assertEquals(3, results.getOptInToday());
         assertEquals(4, results.getOptOutToday());
-        assertEquals(7, results.getTotalToday());
+        assertEquals(optOutProcessing.optOutInformationList.size(), results.getTotalToday());
     }
 
     @Test
@@ -82,7 +82,7 @@ class OptOutProcessorTest {
         S3MockAPIExtension.createFile(Files.readString(Paths.get("src/test/resources/" + emptyFileName), StandardCharsets.UTF_8), emptyFileName);
         OptOutResults results = optOutProcessing.process(emptyFileName, TEST_BFD_BUCKET_NAME, TEST_ENDPOINT);
         assertEquals(0, optOutProcessing.optOutInformationList.size());
-        assertEquals(0, results.getTotalToday());
+        assertEquals(optOutProcessing.optOutInformationList.size(), results.getTotalToday());
         S3MockAPIExtension.deleteFile(emptyFileName);
     }
 
@@ -160,7 +160,7 @@ class OptOutProcessorTest {
         final int OPT_IN_TOTAL = 9;
         final int OPT_OUT_TOTAL = 7;
 
-        when(resultSet.next()).thenReturn(true).thenReturn(true).thenReturn(false);
+        when(resultSet.next()).thenReturn(true).thenReturn(false);
         when(resultSet.getInt(OPT_IN_RESULTSET_STRING)).thenReturn(OPT_IN_TOTAL);
         when(resultSet.getInt(OPT_OUT_RESULTSET_STRING)).thenReturn(OPT_OUT_TOTAL);
 

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutProcessorTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutProcessorTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -28,11 +29,14 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith({S3MockAPIExtension.class})
 class OptOutProcessorTest {
+    private static final ResultSet resultSet = mock(ResultSet.class);
+    private static final PreparedStatement preparedStatement = mock(PreparedStatement.class);
     private static final Connection dbConnection = mock(Connection.class);
     private static final MockedStatic<OptOutParameterStore> parameterStore = mockStatic(OptOutParameterStore.class);
     private static final String DATE = new SimpleDateFormat(EFFECTIVE_DATE_PATTERN).format(new Date());
     private static final String MBI = "DUMMY000001";
     private static final String TRAILER_COUNT = "0000000001";
+    private static final int TEST_TOTAL_RESULT_COUNT = 7;
     private static String validLine(char isOptOut) {
         return MBI + isOptOut;
     }
@@ -44,7 +48,10 @@ class OptOutProcessorTest {
 
         mockStatic(DriverManager.class)
                 .when(() ->  DriverManager.getConnection(anyString(), anyString(), anyString())).thenReturn(dbConnection);
-        when(dbConnection.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+        when(dbConnection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery(anyString())).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true).thenReturn(false);
+        when(resultSet.getInt(any())).thenReturn(TEST_TOTAL_RESULT_COUNT);
     }
 
     @BeforeEach

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutProcessorTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutProcessorTest.java
@@ -63,16 +63,18 @@ class OptOutProcessorTest {
     @Test
     void processTest() throws URISyntaxException {
         optOutProcessing.isRejected = false;
-        optOutProcessing.process(TEST_FILE_NAME, TEST_BFD_BUCKET_NAME, TEST_ENDPOINT);
+        OptOutResults results = optOutProcessing.process(TEST_FILE_NAME, TEST_BFD_BUCKET_NAME, TEST_ENDPOINT);
         assertEquals(7, optOutProcessing.optOutInformationList.size());
+        assertEquals(7, results.getTotalToday());
     }
 
     @Test
     void processEmptyFileTest() throws IOException, URISyntaxException {
         var emptyFileName = "emptyDummy.txt";
         S3MockAPIExtension.createFile(Files.readString(Paths.get("src/test/resources/" + emptyFileName), StandardCharsets.UTF_8), emptyFileName);
-        optOutProcessing.process(emptyFileName, TEST_BFD_BUCKET_NAME, TEST_ENDPOINT);
+        OptOutResults results = optOutProcessing.process(emptyFileName, TEST_BFD_BUCKET_NAME, TEST_ENDPOINT);
         assertEquals(0, optOutProcessing.optOutInformationList.size());
+        assertEquals(0, results.getTotalToday());
         S3MockAPIExtension.deleteFile(emptyFileName);
     }
 
@@ -140,6 +142,12 @@ class OptOutProcessorTest {
         assertEquals(RecordStatus.ACCEPTED.toString(), optOutProcessing.getRecordStatus());
         optOutProcessing.isRejected = true;
         assertEquals(RecordStatus.REJECTED.toString(), optOutProcessing.getRecordStatus());
+    }
+
+    @Test
+    void getOptOutResultsTest() {
+        OptOutResults results = optOutProcessing.getOptOutResults();
+        assertEquals(results, null);
     }
 
 }

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutProcessorTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutProcessorTest.java
@@ -49,6 +49,7 @@ class OptOutProcessorTest {
         mockStatic(DriverManager.class)
                 .when(() ->  DriverManager.getConnection(anyString(), anyString(), anyString())).thenReturn(dbConnection);
         when(dbConnection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        when(dbConnection.createStatement()).thenReturn(preparedStatement);
         when(preparedStatement.executeQuery(anyString())).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(true).thenReturn(false);
         when(resultSet.getInt(any())).thenReturn(TEST_TOTAL_RESULT_COUNT);

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutResultsTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutResultsTest.java
@@ -17,6 +17,8 @@ public class OptOutResultsTest {
 
         assertEquals(todayOptIn, optOutResults.getOptInToday());
         assertEquals(todayOptOut, optOutResults.getOptOutToday());
+        assertEquals(totalOptedIn, optOutResults.getOptInTotal());
+        assertEquals(totalOptedOut, optOutResults.getOptOutTotal());
         assertEquals(todayOptIn + todayOptOut, optOutResults.getTotalToday());
         assertEquals(totalOptedIn + totalOptedOut, optOutResults.getTotalAllTime());
     }

--- a/optout/src/test/java/gov/cms/ab2d/optout/OptOutResultsTest.java
+++ b/optout/src/test/java/gov/cms/ab2d/optout/OptOutResultsTest.java
@@ -1,0 +1,24 @@
+package gov.cms.ab2d.optout;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class OptOutResultsTest {
+    
+    @Test 
+    public void itStoresValuesCorrectly() {
+        int todayOptIn = 1;
+        int todayOptOut = 1;
+
+        int totalOptedIn = 1;
+        int totalOptedOut = 1;
+        OptOutResults optOutResults = new OptOutResults(todayOptIn, todayOptOut, totalOptedIn, totalOptedOut);
+
+        assertEquals(todayOptIn, optOutResults.getOptInToday());
+        assertEquals(todayOptOut, optOutResults.getOptOutToday());
+        assertEquals(todayOptIn + todayOptOut, optOutResults.getTotalToday());
+        assertEquals(totalOptedIn + totalOptedOut, optOutResults.getTotalAllTime());
+    }
+
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6124

## 🛠 Changes

Add more information to the lambda completion slack message with metrics about processed opt out information.

## ℹ️ Context for reviewers

I want to make sure my approach here is good. I wanted to avoid going to the database multiple times for performance reasons. 

## ✅ Acceptance Validation

Tested on IMPL environment:
<img width="1159" alt="Screenshot 2024-06-11 at 1 51 21 PM" src="https://github.com/CMSgov/ab2d-lambdas/assets/87499456/ccc6e869-2911-41b7-bec9-a8e57a132d03">
<img width="367" alt="Screenshot 2024-06-11 at 1 54 38 PM" src="https://github.com/CMSgov/ab2d-lambdas/assets/87499456/1da45a8f-bd1c-4b6b-b2d1-108cac3d63c2">

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
