### PR TITLE
updating jdk version in jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
 
     tools {
         gradle "gradle-7.2"
-        jdk 'adoptjdk13'
+        jdk 'openjdk17'
     }
 
     stages {


### PR DESCRIPTION
This is to update the jdk version that the jenkins job is looking for to the version we're using on the host node.