### PR TITLE
Changed opt out flag to share_data

### DIFF
--- a/attribution-data-file-share/src/main/java/gov/cms/ab2d/attributiondatashare/AttributionDataShareHelper.java
+++ b/attribution-data-file-share/src/main/java/gov/cms/ab2d/attributiondatashare/AttributionDataShareHelper.java
@@ -40,7 +40,7 @@ public class AttributionDataShareHelper {
             writer.newLine();
             long records = 0;
             while (rs.next()) {
-                var line = getResponseLine(rs.getString("mbi"), rs.getDate("effective_date"), rs.getBoolean("opt_out_flag"));
+                var line = getResponseLine(rs.getString("mbi"), rs.getDate("effective_date"), rs.getBoolean("share_data"));
                 writer.write(line);
                 writer.newLine();
                 records++;

--- a/attribution-data-file-share/src/test/java/gov/cms/ab2d/attributiondatashare/AttributionDataShareTest.java
+++ b/attribution-data-file-share/src/test/java/gov/cms/ab2d/attributiondatashare/AttributionDataShareTest.java
@@ -55,7 +55,7 @@ class AttributionDataShareTest {
         var rs = new MockResultSet("");
         rs.addColumn("mbi", Arrays.asList(MBI_1, MBI_2));
         rs.addColumn("effective_date", Arrays.asList("2024-02-26", null));
-        rs.addColumn("opt_out_flag", Arrays.asList(true, null));
+        rs.addColumn("share_data", Arrays.asList(true, null));
         when(connection.createStatement()).thenReturn(stmt);
 
         when(getExecuteQuery(stmt)).thenReturn(rs);

--- a/optout/src/main/java/gov/cms/ab2d/optout/OptOutConstants.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/OptOutConstants.java
@@ -22,7 +22,7 @@ public class OptOutConstants {
     public static final String CONF_FILE_NAME = "#EFT.ON.AB2D.NGD.CONF.";
     public static final String CONF_FILE_NAME_PATTERN = "'D'yyMMdd.'T'HHmmsss";
     public static final String UPDATE_STATEMENT = "UPDATE public.current_mbi\n" +
-            "SET opt_out_flag = ?, effective_date = current_date\n" +
+            "SET share_data = ?, effective_date = current_date\n" +
             "WHERE mbi = ?";
 
     private OptOutConstants() {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6151

## 🛠 Changes

We should update the column name to data_sharing or share_data:
column name of opt_out is updated to share_data
no reduction in test coverage

## ℹ️ Context

1-800 opt out was rolled out on 4/6. The data sharing preference field in ICD can be true or false (or blank): When it is true, it means the beneficiary has chosen to share their data; when it is false, it means beneficiary has chosen to not share their data. The data sharing preference (specific in ICD) field is currently mapped to opt_out, which causes confusion as the column name contradicts the meaning of the field. column name of opt_out is updated to share_data


<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Verify to make sure that changes update the table column name .

