### PR TITLE
Update publish lambda workflow

### DIFF
--- a/.github/workflows/publish-lambdas.yml
+++ b/.github/workflows/publish-lambdas.yml
@@ -1,7 +1,6 @@
 name: publish-lambdas
 
 on:
-  pull_request:
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/publish-lambdas.yml
+++ b/.github/workflows/publish-lambdas.yml
@@ -4,25 +4,15 @@ on:
   pull_request:
   workflow_call:
     inputs:
-      environment:
-        required: true
-        type: string
       ref:
         required: false
         type: string
+        description: 'Branch name - used when called by cmsgov/ab2d/deploy-lambda.yml'
     outputs:
       build_version:
         description: "The lambdas build version"
         value: ${{ jobs.publish.outputs.build_version }}
   workflow_dispatch:
-    inputs:
-      environment:
-        required: true
-        type: choice
-        options:
-          - dev
-          - test
-          - prod
 
 jobs:
   publish:
@@ -32,7 +22,6 @@ jobs:
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       AWS_REGION: ${{ vars.AWS_REGION }}
-      DEPLOYMENT_ENV: ${{ vars[format('{0}_DEPLOYMENT_ENV', github.event.inputs.environment || inputs.environment)] }}
 
     steps:
       - name: Checkout Code
@@ -42,95 +31,94 @@ jobs:
           repository: 'cmsgov/ab2d-lambdas'
           ref: ${{ inputs.ref || github.ref }}
 
-#      - name: Remount /tmp with exec permissions
-#        run: |
-#          echo "Remounting /tmp with exec permissions..."
-#          sudo mount /tmp -o remount,exec
-#
-#      - name: Verify /tmp Permissions
-#        run: |
-#          echo "Checking /tmp permissions..."
-#          mount | grep /tmp
-#          ls -ld /tmp
-#
-#      - uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
-#        with:
-#          distribution: 'adopt'
-#          java-version: '15'
-#
-#      - uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
-#        with:
-#          gradle-version: 7.2
-#
-#      - uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
-#        env:
-#          AWS_REGION: ${{ vars.AWS_REGION }}
-#        with:
-#          params: |
-#            ARTIFACTORY_URL=/artifactory/url
-#            ARTIFACTORY_USER=/artifactory/user
-#            ARTIFACTORY_PASSWORD=/artifactory/password
-#            SONAR_HOST_URL=/sonarqube/url
-#            SONAR_TOKEN=/sonarqube/token
-#
-#      - name: Verify Required Libraries
-#        run: |
-#          echo "Checking for required system libraries..."
-#          ldd --version || echo "ldd (glibc) is not installed!"
-#          ldconfig -p | grep "libstdc++" || echo "libstdc++ is missing!"
-#          ldconfig -p | grep "zlib" || echo "zlib is missing!"
-#
-#      - name: Build Lambdas
-#        run: |
-#          ./gradlew -b build.gradle
-#
-#      - name: Test Lambdas
-#        run: |
-#          ./gradlew clean test --info -b build.gradle
-#
-#      - name: Build Jars
-#        run: |
-#          ./gradlew buildZip --info -b build.gradle
-#
-#      - name: SonarQube Analysis
-#        run: |
-#          ./gradlew sonarqube -Dsonar.projectKey=ab2d-lambdas -Dsonar.host.url=https://sonarqube.cloud.cms.gov
-#
-#      - name: Quality Gate
-#        run: |
-#          echo "Waiting for SonarQube Quality Gate..."
-#          sleep 600  # Simulate a 10-minute wait (adjust based on actual implementation)
-#
-#      - name: SBOM
-#        run: |
-#          ./gradlew cyclonedxBom --info -b build.gradle
-#
+      - name: Remount /tmp with exec permissions
+        run: |
+          echo "Remounting /tmp with exec permissions..."
+          sudo mount /tmp -o remount,exec
+
+      - name: Verify /tmp Permissions
+        run: |
+          echo "Checking /tmp permissions..."
+          mount | grep /tmp
+          ls -ld /tmp
+
+      - uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
+        with:
+          distribution: 'adopt'
+          java-version: '15'
+
+      - uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
+        with:
+          gradle-version: 7.2
+
+      - uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            ARTIFACTORY_URL=/artifactory/url
+            ARTIFACTORY_USER=/artifactory/user
+            ARTIFACTORY_PASSWORD=/artifactory/password
+            SONAR_HOST_URL=/sonarqube/url
+            SONAR_TOKEN=/sonarqube/token
+
+      - name: Verify Required Libraries
+        run: |
+          echo "Checking for required system libraries..."
+          ldd --version || echo "ldd (glibc) is not installed!"
+          ldconfig -p | grep "libstdc++" || echo "libstdc++ is missing!"
+          ldconfig -p | grep "zlib" || echo "zlib is missing!"
+
+      - name: Build Lambdas
+        run: |
+          ./gradlew -b build.gradle
+
+      - name: Test Lambdas
+        run: |
+          ./gradlew clean test --info -b build.gradle
+
+      - name: Build Jars
+        run: |
+          ./gradlew buildZip --info -b build.gradle
+
+      - name: SonarQube Analysis
+        run: |
+          ./gradlew sonarqube -Dsonar.projectKey=ab2d-lambdas -Dsonar.host.url=https://sonarqube.cloud.cms.gov
+
+      - name: Quality Gate
+        run: |
+          echo "Waiting for SonarQube Quality Gate..."
+          sleep 600  # Simulate a 10-minute wait (adjust based on actual implementation)
+
+      - name: SBOM
+        run: |
+          ./gradlew cyclonedxBom --info -b build.gradle
+
       - name: Publish Lambdas
         id: publish_lambdas
-        run: echo "build_version=1.1.0" >> "$GITHUB_OUTPUT"
-#        run: |
-#          echo "Checking for unpublished artifacts..."
-#          DEPLOY_SCRIPT=""
-#          VERSION_PUBLISHED_LIST=$(./gradlew -q lookForArtifacts | tr -d '\r')
-#
-#          while IFS= read -r line; do
-#            ARTIFACTORY_INFO=($(echo $line | tr ":" "\n"))
-#            if [[ "${ARTIFACTORY_INFO[1]}" == "false" ]]; then
-#              echo "Deploying ${ARTIFACTORY_INFO[0]}"
-#              DEPLOY_SCRIPT+="${ARTIFACTORY_INFO[0]}:artifactoryPublish "
-#            fi
-#          done <<< "$VERSION_PUBLISHED_LIST"
-#
-#          if [[ -n "$DEPLOY_SCRIPT" ]]; then
-#            echo "Publishing: $DEPLOY_SCRIPT"
-#            ./gradlew $DEPLOY_SCRIPT -b build.gradle \
-#              -Dusername="${ARTIFACTORY_USER}" \
-#              -Dpassword="${ARTIFACTORY_PASSWORD}" \
-#              -Drepository_url="${ARTIFACTORY_URL}"
-#          else
-#            echo "No new artifacts to publish."
-#          fi
-#
-#          BUILD_VERSION=$(./gradlew properties -q | grep "version:" | awk '{print $2}')
-#          echo "Build version: $BUILD_VERSION"
-#          echo "build_version=$BUILD_VERSION" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "Checking for unpublished artifacts..."
+          DEPLOY_SCRIPT=""
+          VERSION_PUBLISHED_LIST=$(./gradlew -q lookForArtifacts | tr -d '\r')
+
+          while IFS= read -r line; do
+            ARTIFACTORY_INFO=($(echo $line | tr ":" "\n"))
+            if [[ "${ARTIFACTORY_INFO[1]}" == "false" ]]; then
+              echo "Deploying ${ARTIFACTORY_INFO[0]}"
+              DEPLOY_SCRIPT+="${ARTIFACTORY_INFO[0]}:artifactoryPublish "
+            fi
+          done <<< "$VERSION_PUBLISHED_LIST"
+
+          if [[ -n "$DEPLOY_SCRIPT" ]]; then
+            echo "Publishing: $DEPLOY_SCRIPT"
+            ./gradlew $DEPLOY_SCRIPT -b build.gradle \
+              -Dusername="${ARTIFACTORY_USER}" \
+              -Dpassword="${ARTIFACTORY_PASSWORD}" \
+              -Drepository_url="${ARTIFACTORY_URL}"
+          else
+            echo "No new artifacts to publish."
+          fi
+
+          BUILD_VERSION=$(./gradlew properties -q | grep "version:" | awk '{print $2}')
+          echo "Build version: $BUILD_VERSION"
+          echo "build_version=$BUILD_VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-lambdas.yml
+++ b/.github/workflows/publish-lambdas.yml
@@ -7,6 +7,10 @@ on:
       environment:
         required: true
         type: string
+    outputs:
+      build_version:
+        description: "The lambdas build version"
+        value: ${{ jobs.publish.outputs.build_version }}
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/publish-lambdas.yml
+++ b/.github/workflows/publish-lambdas.yml
@@ -21,7 +21,7 @@ jobs:
   publish:
     runs-on: self-hosted
     outputs:
-      output_1: ${{ steps.publish_lambdas.build_version }}
+      build_version: ${{ steps.publish_lambdas.build_version }}
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       AWS_REGION: ${{ vars.AWS_REGION }}

--- a/.github/workflows/publish-lambdas.yml
+++ b/.github/workflows/publish-lambdas.yml
@@ -25,7 +25,7 @@ jobs:
   publish:
     runs-on: self-hosted
     outputs:
-      build_version: ${{ steps.publish_lambdas.build_version }}
+      build_version: ${{ steps.publish_lambdas.outputs.build_version }}
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       AWS_REGION: ${{ vars.AWS_REGION }}

--- a/.github/workflows/publish-lambdas.yml
+++ b/.github/workflows/publish-lambdas.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
+          # specify repo and ref (branch) to allow this workflow to be called from cmsgov/ab2d/deploy-lambda.yml
           repository: 'cmsgov/ab2d-lambdas'
           ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/workflows/publish-lambdas.yml
+++ b/.github/workflows/publish-lambdas.yml
@@ -34,7 +34,9 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-        
+        with:
+          repository: 'cmsgov/ab2d-lambdas'
+
       - name: Remount /tmp with exec permissions
         run: |
           echo "Remounting /tmp with exec permissions..."

--- a/.github/workflows/publish-lambdas.yml
+++ b/.github/workflows/publish-lambdas.yml
@@ -7,6 +7,9 @@ on:
       environment:
         required: true
         type: string
+      ref:
+        required: false
+        type: string
     outputs:
       build_version:
         description: "The lambdas build version"
@@ -36,6 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'cmsgov/ab2d-lambdas'
+          ref: ${{ inputs.ref || github.ref }}
 
 #      - name: Remount /tmp with exec permissions
 #        run: |

--- a/.github/workflows/publish-lambdas.yml
+++ b/.github/workflows/publish-lambdas.yml
@@ -37,94 +37,95 @@ jobs:
         with:
           repository: 'cmsgov/ab2d-lambdas'
 
-      - name: Remount /tmp with exec permissions
-        run: |
-          echo "Remounting /tmp with exec permissions..."
-          sudo mount /tmp -o remount,exec
-
-      - name: Verify /tmp Permissions
-        run: |
-          echo "Checking /tmp permissions..."
-          mount | grep /tmp
-          ls -ld /tmp
-
-      - uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
-        with:
-          distribution: 'adopt'
-          java-version: '15'
-
-      - uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
-        with:
-          gradle-version: 7.2
-
-      - uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
-        env:
-          AWS_REGION: ${{ vars.AWS_REGION }}
-        with:
-          params: |
-            ARTIFACTORY_URL=/artifactory/url
-            ARTIFACTORY_USER=/artifactory/user
-            ARTIFACTORY_PASSWORD=/artifactory/password
-            SONAR_HOST_URL=/sonarqube/url
-            SONAR_TOKEN=/sonarqube/token
-
-      - name: Verify Required Libraries
-        run: |
-          echo "Checking for required system libraries..."
-          ldd --version || echo "ldd (glibc) is not installed!"
-          ldconfig -p | grep "libstdc++" || echo "libstdc++ is missing!"
-          ldconfig -p | grep "zlib" || echo "zlib is missing!"
-
-      - name: Build Lambdas
-        run: |
-          ./gradlew -b build.gradle
-
-      - name: Test Lambdas
-        run: |
-          ./gradlew clean test --info -b build.gradle
-
-      - name: Build Jars
-        run: |
-          ./gradlew buildZip --info -b build.gradle
-
-      - name: SonarQube Analysis
-        run: |
-          ./gradlew sonarqube -Dsonar.projectKey=ab2d-lambdas -Dsonar.host.url=https://sonarqube.cloud.cms.gov
-
-      - name: Quality Gate
-        run: |
-          echo "Waiting for SonarQube Quality Gate..."
-          sleep 600  # Simulate a 10-minute wait (adjust based on actual implementation)
-
-      - name: SBOM
-        run: |
-          ./gradlew cyclonedxBom --info -b build.gradle
-
+#      - name: Remount /tmp with exec permissions
+#        run: |
+#          echo "Remounting /tmp with exec permissions..."
+#          sudo mount /tmp -o remount,exec
+#
+#      - name: Verify /tmp Permissions
+#        run: |
+#          echo "Checking /tmp permissions..."
+#          mount | grep /tmp
+#          ls -ld /tmp
+#
+#      - uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
+#        with:
+#          distribution: 'adopt'
+#          java-version: '15'
+#
+#      - uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
+#        with:
+#          gradle-version: 7.2
+#
+#      - uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+#        env:
+#          AWS_REGION: ${{ vars.AWS_REGION }}
+#        with:
+#          params: |
+#            ARTIFACTORY_URL=/artifactory/url
+#            ARTIFACTORY_USER=/artifactory/user
+#            ARTIFACTORY_PASSWORD=/artifactory/password
+#            SONAR_HOST_URL=/sonarqube/url
+#            SONAR_TOKEN=/sonarqube/token
+#
+#      - name: Verify Required Libraries
+#        run: |
+#          echo "Checking for required system libraries..."
+#          ldd --version || echo "ldd (glibc) is not installed!"
+#          ldconfig -p | grep "libstdc++" || echo "libstdc++ is missing!"
+#          ldconfig -p | grep "zlib" || echo "zlib is missing!"
+#
+#      - name: Build Lambdas
+#        run: |
+#          ./gradlew -b build.gradle
+#
+#      - name: Test Lambdas
+#        run: |
+#          ./gradlew clean test --info -b build.gradle
+#
+#      - name: Build Jars
+#        run: |
+#          ./gradlew buildZip --info -b build.gradle
+#
+#      - name: SonarQube Analysis
+#        run: |
+#          ./gradlew sonarqube -Dsonar.projectKey=ab2d-lambdas -Dsonar.host.url=https://sonarqube.cloud.cms.gov
+#
+#      - name: Quality Gate
+#        run: |
+#          echo "Waiting for SonarQube Quality Gate..."
+#          sleep 600  # Simulate a 10-minute wait (adjust based on actual implementation)
+#
+#      - name: SBOM
+#        run: |
+#          ./gradlew cyclonedxBom --info -b build.gradle
+#
       - name: Publish Lambdas
         id: publish_lambdas
-        run: |
-          echo "Checking for unpublished artifacts..."
-          DEPLOY_SCRIPT=""
-          VERSION_PUBLISHED_LIST=$(./gradlew -q lookForArtifacts | tr -d '\r')
-
-          while IFS= read -r line; do
-            ARTIFACTORY_INFO=($(echo $line | tr ":" "\n"))
-            if [[ "${ARTIFACTORY_INFO[1]}" == "false" ]]; then
-              echo "Deploying ${ARTIFACTORY_INFO[0]}"
-              DEPLOY_SCRIPT+="${ARTIFACTORY_INFO[0]}:artifactoryPublish "
-            fi
-          done <<< "$VERSION_PUBLISHED_LIST"
-
-          if [[ -n "$DEPLOY_SCRIPT" ]]; then
-            echo "Publishing: $DEPLOY_SCRIPT"
-            ./gradlew $DEPLOY_SCRIPT -b build.gradle \
-              -Dusername="${ARTIFACTORY_USER}" \
-              -Dpassword="${ARTIFACTORY_PASSWORD}" \
-              -Drepository_url="${ARTIFACTORY_URL}"
-          else
-            echo "No new artifacts to publish."
-          fi
-
-          BUILD_VERSION=$(./gradlew properties -q | grep "version:" | awk '{print $2}')
-          echo "Build version: $BUILD_VERSION"
-          echo "build_version=$BUILD_VERSION" >> "$GITHUB_OUTPUT"
+        run: echo "build_version=1.1.0" >> "$GITHUB_OUTPUT"
+#        run: |
+#          echo "Checking for unpublished artifacts..."
+#          DEPLOY_SCRIPT=""
+#          VERSION_PUBLISHED_LIST=$(./gradlew -q lookForArtifacts | tr -d '\r')
+#
+#          while IFS= read -r line; do
+#            ARTIFACTORY_INFO=($(echo $line | tr ":" "\n"))
+#            if [[ "${ARTIFACTORY_INFO[1]}" == "false" ]]; then
+#              echo "Deploying ${ARTIFACTORY_INFO[0]}"
+#              DEPLOY_SCRIPT+="${ARTIFACTORY_INFO[0]}:artifactoryPublish "
+#            fi
+#          done <<< "$VERSION_PUBLISHED_LIST"
+#
+#          if [[ -n "$DEPLOY_SCRIPT" ]]; then
+#            echo "Publishing: $DEPLOY_SCRIPT"
+#            ./gradlew $DEPLOY_SCRIPT -b build.gradle \
+#              -Dusername="${ARTIFACTORY_USER}" \
+#              -Dpassword="${ARTIFACTORY_PASSWORD}" \
+#              -Drepository_url="${ARTIFACTORY_URL}"
+#          else
+#            echo "No new artifacts to publish."
+#          fi
+#
+#          BUILD_VERSION=$(./gradlew properties -q | grep "version:" | awk '{print $2}')
+#          echo "Build version: $BUILD_VERSION"
+#          echo "build_version=$BUILD_VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-lambdas.yml
+++ b/.github/workflows/publish-lambdas.yml
@@ -20,7 +20,8 @@ on:
 jobs:
   publish:
     runs-on: self-hosted
-
+    outputs:
+      output_1: ${{ steps.publish_lambdas.build_version }}
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       AWS_REGION: ${{ vars.AWS_REGION }}
@@ -94,6 +95,7 @@ jobs:
           ./gradlew cyclonedxBom --info -b build.gradle
 
       - name: Publish Lambdas
+        id: publish_lambdas
         run: |
           echo "Checking for unpublished artifacts..."
           DEPLOY_SCRIPT=""
@@ -119,3 +121,4 @@ jobs:
 
           BUILD_VERSION=$(./gradlew properties -q | grep "version:" | awk '{print $2}')
           echo "Build version: $BUILD_VERSION"
+          echo "build_version=$BUILD_VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6588

## 🛠 Changes

- Update `publish-lambdas.yml` to allow it to be used by a workflow in the **ab2d** repo. 
   - See related PR below
- Add `build_version` as a workflow output 
- Remove environment as it's not relevant to publishing lambdas

## Related PRs

- https://github.com/CMSgov/ab2d/pull/1448

## ℹ️ Context

This PR is related to https://github.com/CMSgov/ab2d/pull/1448 which migrates this Jenkins job: 
- https://jenkins.ab2d.cms.gov/job/AB2D-Ops/job/Terraform/job/Deploy%20Lambda/build?delay=0sec

This Jenkins job has a `RUN_BUILD_JOB` parameter. In order to make this workflow callable from the ab2d workflow in order to build lambdas, changes are required.  

## 🧪 Validation

- Tested manually 
- Tested from this workflow in ab2d that the lambdas can be build and published: https://github.com/CMSgov/ab2d/actions/runs/13703751847/job/38323875429
- Verified `build_version` is output successfully when calling workflow from the ab2d repo